### PR TITLE
Added findFree() which loops through given port range to look for free port

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+indent_style = space
+indent_size = 4
+

--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
-    "name": "tcp-port-used",
-    "version": "0.1.2",
-    "description": "A simple Node.js module to check if a TCP port is already bound.",
-    "main": "index.js",
-    "scripts": {
-        "test" : "./node_modules/.bin/mocha --reporter=list ./test.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/jut-io/tcp-port-used.git"
-    },
-    "keywords": [
-        "tcp",
-        "port",
-        "available",
-        "free",
-        "check",
-        "networking"
-    ],
-    "author": "Edmond Meinfelder",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/jut-io/tcp-port-used/issues"
-    },
-    "homepage": "https://github.com/jut-io/tcp-port-used",
-    "dependencies": {
-        "debug": "0.7.4",
-        "is2": "0.0.9",
-        "q": "0.9.7"
-    },
-    "devDependencies": {
-        "mocha": "1.15.0"
-    }
+  "name": "tcp-port-used",
+  "version": "0.1.2",
+  "description": "A simple Node.js module to check if a TCP port is already bound.",
+  "main": "index.js",
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --reporter=list ./test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jut-io/tcp-port-used.git"
+  },
+  "keywords": [
+    "tcp",
+    "port",
+    "available",
+    "free",
+    "check",
+    "networking"
+  ],
+  "author": "Edmond Meinfelder",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jut-io/tcp-port-used/issues"
+  },
+  "homepage": "https://github.com/jut-io/tcp-port-used",
+  "dependencies": {
+    "async": "^2.3.0",
+    "debug": "0.7.4",
+    "is2": "0.0.9",
+    "q": "0.9.7"
+  },
+  "devDependencies": {
+    "mocha": "1.15.0"
+  }
 }


### PR DESCRIPTION
I needed a simple method to look for open port, and I was able to implement it thanks to tcp-port-used.

* Find currently open port with a given port range. It simply uses check()
+ * recursively for each port until it finds an available port.
+ * min/max ports are checked inclusively (10~19 will check both 10 and 19)
+ * if no ports are available, the promise will be rejected