### PR TITLE
Remove Q & Other Updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ exports.waitUntilUsed = waitUntilUsed;
 exports.waitForStatus = waitForStatus;
 
 var is = require('is2');
-var Q = require('q');
 var net = require('net');
 var util = require('util');
 var debug = require('debug')('tcp-port-used');
@@ -21,6 +20,19 @@ var debug = require('debug')('tcp-port-used');
 // Global Values
 var TIMEOUT = 2000;
 var RETRYTIME = 250;
+
+function getDeferred() {
+    var resolve, reject, promise = new Promise(function(res, rej) {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        resolve: resolve,
+        reject: reject,
+        promise: promise
+    };
+}
 
 /**
  * Creates an options object from all the possible arguments
@@ -63,7 +75,7 @@ function makeOptionsObj(port, host, inUse, retryTimeMs, timeOutMs) {
  */
 function check(port, host) {
 
-    var deferred = Q.defer();
+    var deferred = getDeferred();
     var inUse = true;
     var client;
 
@@ -147,7 +159,7 @@ function check(port, host) {
  */
 function waitForStatus(port, host, inUse, retryTimeMs, timeOutMs) {
 
-    var deferred = Q.defer();
+    var deferred = getDeferred();
     var timeoutId;
     var timedout = false;
     var retryId;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "homepage": "https://github.com/jut-io/tcp-port-used",
     "dependencies": {
         "debug": "^3.1.0",
-        "is2": "0.0.9",
-        "q": "0.9.7"
+        "is2": "0.0.9"
     },
     "devDependencies": {
         "mocha": "1.15.0"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     },
     "homepage": "https://github.com/jut-io/tcp-port-used",
     "dependencies": {
-        "debug": "^3.1.0",
-        "is2": "0.0.9"
+        "debug": "3.1.0",
+        "is2": "2.0.1"
     },
     "devDependencies": {
         "mocha": "1.15.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/jut-io/tcp-port-used.git"
+        "url": "git://github.com/stdarg/tcp-port-used.git"
     },
     "keywords": [
         "tcp",
@@ -21,9 +21,9 @@
     "author": "Edmond Meinfelder",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/jut-io/tcp-port-used/issues"
+        "url": "https://github.com/stdargtcp-port-used/issues"
     },
-    "homepage": "https://github.com/jut-io/tcp-port-used",
+    "homepage": "https://github.com/stdarg/tcp-port-used",
     "dependencies": {
         "debug": "3.1.0",
         "is2": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
         "is2": "2.0.1"
     },
     "devDependencies": {
-        "mocha": "1.15.0"
+        "mocha": "5.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A simple Node.js module to check if a TCP port is already bound.",
     "main": "index.js",
     "scripts": {
-        "test" : "./node_modules/.bin/mocha --reporter=list ./test.js"
+        "test": "./node_modules/.bin/mocha --reporter=list ./test.js"
     },
     "repository": {
         "type": "git",
@@ -25,7 +25,7 @@
     },
     "homepage": "https://github.com/jut-io/tcp-port-used",
     "dependencies": {
-        "debug": "0.7.4",
+        "debug": "^3.1.0",
         "is2": "0.0.9",
         "q": "0.9.7"
     },


### PR DESCRIPTION
On the back of the Debug update PR, this removes Q, as all maintained versions of Node support Promises. It also bumps all the dependencies to latest (tested in Node v4 and v8) and updates the repo URLs.

It should be a non-breaking change for anyone on Node 4+, but it could be marked a semver major change for those still on Node 0.x.